### PR TITLE
Fix node errors

### DIFF
--- a/docs/content/servers/node.md
+++ b/docs/content/servers/node.md
@@ -23,8 +23,13 @@ const http = require('http');
 const port = parseInt(process.argv[2] || '8080', 10);
 
 const server = http.createServer((req, res) => {
-    const url = new URL(req.url, `http://${req.headers.host}`);
-    if (url.pathname === '/echo') {
+    let pathname;
+    try {
+        pathname = new URL(req.url, `http://${req.headers.host || 'localhost'}`).pathname;
+    } catch {
+        pathname = req.url;
+    }
+    if (pathname === '/echo') {
         let body = '';
         for (const [name, value] of Object.entries(req.headers)) {
             if (Array.isArray(value)) value.forEach(v => body += name + ': ' + v + '\n');

--- a/src/Servers/NodeServer/server.js
+++ b/src/Servers/NodeServer/server.js
@@ -3,8 +3,13 @@ const http = require('http');
 const port = parseInt(process.argv[2] || '8080', 10);
 
 const server = http.createServer((req, res) => {
-    const url = new URL(req.url, `http://${req.headers.host}`);
-    if (url.pathname === '/echo') {
+    let pathname;
+    try {
+        pathname = new URL(req.url, `http://${req.headers.host || 'localhost'}`).pathname;
+    } catch {
+        pathname = req.url;
+    }
+    if (pathname === '/echo') {
         let body = '';
         for (const [name, value] of Object.entries(req.headers)) {
             if (Array.isArray(value)) value.forEach(v => body += name + ': ' + v + '\n');


### PR DESCRIPTION
The bug: new URL(req.url, "http://") throws TypeError: Invalid URL when Host
  is empty, crashing the Node process. All 102 tests after COMP-HOST-EMPTY-VALUE
   failed because the server was dead.  