### PR TITLE
Fix Lighttpd implementation to echo body on POST /

### DIFF
--- a/docs/content/servers/lighttpd.md
+++ b/docs/content/servers/lighttpd.md
@@ -31,6 +31,18 @@ server.error-handler = "/index.cgi"
 alias.url = ("/echo" => "/var/www/echo.cgi")
 ```
 
+## Source — `index.cgi`
+
+```bash
+#!/bin/sh
+printf 'Content-Type: text/plain\r\n\r\n'
+if [ "$REQUEST_METHOD" = "POST" ] && [ "${CONTENT_LENGTH:-0}" -gt 0 ] 2>/dev/null; then
+    head -c "$CONTENT_LENGTH"
+else
+    printf 'OK'
+fi
+```
+
 ## Source — `echo.cgi`
 
 ```bash

--- a/src/Servers/LighttpdServer/index.cgi
+++ b/src/Servers/LighttpdServer/index.cgi
@@ -1,7 +1,7 @@
 #!/bin/sh
 printf 'Content-Type: text/plain\r\n\r\n'
-if [ "$REQUEST_METHOD" = "POST" ]; then
-    cat
+if [ "$REQUEST_METHOD" = "POST" ] && [ "${CONTENT_LENGTH:-0}" -gt 0 ] 2>/dev/null; then
+    head -c "$CONTENT_LENGTH"
 else
     printf 'OK'
 fi


### PR DESCRIPTION
Replaced cat with head -c "$CONTENT_LENGTH" so POST / correctly echoes the request body instead of hanging (CGI scripts must read exactly CONTENT_LENGTH bytes, not until EOF).    