### PR TITLE
Update to PHP 8.5

### DIFF
--- a/src/Servers/PhpServer/Dockerfile
+++ b/src/Servers/PhpServer/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli
+FROM php:8.5-cli
 COPY src/Servers/PhpServer/index.php /app/index.php
 WORKDIR /app
 EXPOSE 8080


### PR DESCRIPTION
The PHP CLI server is only for develop.
It isn't for production.

In my own tests fail a lot with http standards at return code values.
