### PR TITLE
Fix Gunicorn chunked request-body handling in the probe app

### DIFF
--- a/src/Servers/GunicornServer/app.py
+++ b/src/Servers/GunicornServer/app.py
@@ -27,12 +27,21 @@ def app(environ, start_response):
         start_response('200 OK', [('Content-Type', 'text/plain')])
         return [body]
 
-    start_response('200 OK', [('Content-Type', 'text/plain')])
     if environ['REQUEST_METHOD'] == 'POST':
-        try:
-            length = int(environ.get('CONTENT_LENGTH', 0) or 0)
-        except ValueError:
-            length = 0
-        body = environ['wsgi.input'].read(length) if length > 0 else b''
+        if environ.get('HTTP_TRANSFER_ENCODING'):
+            # chunked request: no Content-Length; Gunicorn's worker dechunks, so read to EOF
+            try:
+                body = environ['wsgi.input'].read()
+            except Exception:
+                start_response('400 Bad Request', [('Content-Type', 'text/plain')])
+                return [b'']
+        else:
+            try:
+                length = int(environ.get('CONTENT_LENGTH', 0) or 0)
+            except ValueError:
+                length = 0
+            body = environ['wsgi.input'].read(length) if length > 0 else b''
+        start_response('200 OK', [('Content-Type', 'text/plain')])
         return [body]
+    start_response('200 OK', [('Content-Type', 'text/plain')])
     return [b'OK']


### PR DESCRIPTION
The GunicornServer WSGI app read the POST body via `CONTENT_LENGTH` only. A `Transfer-Encoding: chunked` request has no Content-Length, so it read **0 bytes** — the body echoed back empty and the chunk framing was never decoded. That made Gunicorn **fail every chunked test** (valid chunked POSTs, malformed chunks, incomplete chunks) even though its sync worker actually supports chunked.

## Fix
On `Transfer-Encoding`, read `wsgi.input` to EOF (Gunicorn dechunks and provides the decoded body) and return **400** on a decode error. The `Content-Length` path is unchanged, so non-chunked results are unaffected.

## Audit of the other servers
Only Gunicorn was affected. FastPySGI has the same app code but the *server* sets `CONTENT_LENGTH` after dechunking (already passes); Pingora reads via `session.read_request_body()` (dechunks); Glyph/Flask/Uvicorn handle it in-framework. NetCoreServer fails too, but there it's a genuine limitation — its library doesn't decode chunked request bodies.

This PR re-probes Gunicorn; the comment below should show the chunked tests flipping to pass.