### PR TITLE
Pingora: return 400 (not 500) on malformed request bodies

### DIFF
--- a/src/Servers/PingoraServer/src/main.rs
+++ b/src/Servers/PingoraServer/src/main.rs
@@ -63,8 +63,21 @@ impl ProxyHttp for OkProxy {
         let is_post = session.req_header().method == pingora::http::Method::POST;
         let body = if is_post {
             let mut buf = Vec::new();
-            while let Some(chunk) = session.read_request_body().await? {
-                buf.extend_from_slice(&chunk);
+            loop {
+                match session.read_request_body().await {
+                    Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
+                    Ok(None) => break,
+                    // Malformed request body (e.g. bad chunk framing): reject with 400
+                    // instead of letting the error bubble up to Pingora's default 500.
+                    Err(_) => {
+                        let mut header = ResponseHeader::build(400, None)?;
+                        header.insert_header("Content-Length", "0")?;
+                        session
+                            .write_response_header(Box::new(header), true)
+                            .await?;
+                        return Ok(true);
+                    }
+                }
             }
             Bytes::from(buf)
         } else {


### PR DESCRIPTION
## Problem
The Pingora probe app reads the POST body with `session.read_request_body().await?`. On malformed chunk framing, Pingora's body reader returns an `Err`, the `?` propagates out of `request_filter`, and Pingora emits its **default 500** — failing **17** chunk/TE tests (`SMUG-CHUNK-NEGATIVE`, `-HEX-PREFIX`, `-MISSING-TRAILING-CRLF`, `MAL-CHUNK-SIZE-OVERFLOW`, `SMUG-TE-CASE-MISMATCH`, …) that expect `400` or close.

## Fix
The read loop now catches the error and returns a clean **400**. Pingora was already rejecting the bad framing — this just surfaces it as a client error instead of a server error.

Note: this only addresses the `500`s. The separate ~47 `200` failures are Pingora's lenient parsing + the fact that it's a **proxy being scored as a bare origin** (`request_filter` short-circuits, `upstream_peer` is `unreachable!()`), which is a deeper modeling question left as-is.

Engine/server change → re-probes Pingora.