### PR TITLE
fix(lighttpd): stop harness config from masking lighttpd's real status codes

### DIFF
--- a/src/Servers/LighttpdServer/lighttpd.conf
+++ b/src/Servers/LighttpdServer/lighttpd.conf
@@ -3,5 +3,4 @@ server.port = 8080
 index-file.names = ("index.cgi")
 server.modules += ("mod_cgi", "mod_alias")
 cgi.assign = (".cgi" => "")
-server.error-handler = "/index.cgi"
 alias.url = ("/echo" => "/var/www/echo.cgi", "/cookie" => "/var/www/cookie.cgi")


### PR DESCRIPTION
Single harness-config bug fix. The probe exposes the framework's native behavior; this only removes a harness misconfiguration that was *hiding* lighttpd's real status codes — it does not modify any framework's default.

`server.error-handler = "/index.cgi"` made lighttpd re-serve its **own** 4xx/5xx through `index.cgi`, which emits no `Status:` header → every error went out as **200**. That masked lighttpd as maximally lenient (accepted 203/215) when it actually rejects plenty. Removing the line restores lighttpd's default error handling (it sends its own status codes). Normal endpoints are unaffected — they route via `index-file.names` (`/`) and `alias.url` (`/echo`, `/cookie`), not the error handler.

Validated by local re-probe: **53 → 129** scored pass.

(The earlier multi-server version of this PR — `catch`/error-check → 400 on Tomcat/Flask/Gin/Bun/Deno/Kestrel/ServiceStack, plus a Workerman change — was reverted: those modified the framework's default output rather than exposing it. Their native 500/200 and Workerman's behavior are kept as-is.)
