### PR TITLE
feat(grid): "LLM's Choice" ideal-proxy column + drop two inert tests

### DIFF
--- a/src/Http11Probe/TestCases/Suites/ComplianceSuite.cs
+++ b/src/Http11Probe/TestCases/Suites/ComplianceSuite.cs
@@ -1145,29 +1145,6 @@ public static class ComplianceSuite
 
         yield return new TestCase
         {
-            Id = "COMP-405-ALLOW",
-            Description = "405 response must include an Allow header",
-            Category = TestCategory.Compliance,
-            RfcReference = "RFC 9110 §15.5.6",
-            PayloadFactory = ctx => MakeRequest(
-                $"DELETE / HTTP/1.1\r\nHost: {ctx.HostHeader}\r\n\r\n"),
-            Expected = new ExpectedBehavior
-            {
-                Description = "405 + Allow header",
-                CustomValidator = (response, state) =>
-                {
-                    if (response is null)
-                        return TestVerdict.Fail;
-                    if (response.StatusCode == 405)
-                        return response.Headers.ContainsKey("Allow") ? TestVerdict.Pass : TestVerdict.Fail;
-                    // Server didn't return 405 — can't verify the Allow requirement
-                    return TestVerdict.Warn;
-                }
-            }
-        };
-
-        yield return new TestCase
-        {
             Id = "COMP-DATE-HEADER",
             Description = "Origin server must include Date header in responses",
             Category = TestCategory.Compliance,
@@ -1253,31 +1230,6 @@ public static class ComplianceSuite
                     if (response.StatusCode is >= 100 and < 200)
                         return TestVerdict.Fail;
                     return TestVerdict.Pass;
-                }
-            }
-        };
-
-        yield return new TestCase
-        {
-            Id = "COMP-NO-CL-IN-204",
-            Description = "Server must not send Content-Length in a 204 response",
-            Category = TestCategory.Compliance,
-            RfcReference = "RFC 9110 §8.6",
-            PayloadFactory = ctx => MakeRequest(
-                $"OPTIONS / HTTP/1.1\r\nHost: {ctx.HostHeader}\r\n\r\n"),
-            Expected = new ExpectedBehavior
-            {
-                Description = "204 without CL, or 405",
-                CustomValidator = (response, state) =>
-                {
-                    if (response is null)
-                        return TestVerdict.Fail;
-                    if (response.StatusCode == 405)
-                        return TestVerdict.Pass; // Server doesn't support OPTIONS — can't test CL prohibition
-                    if (response.StatusCode == 204)
-                        return response.Headers.ContainsKey("Content-Length") ? TestVerdict.Fail : TestVerdict.Pass;
-                    // Server didn't return 204 — can't verify the CL prohibition
-                    return TestVerdict.Warn;
                 }
             }
         };

--- a/web/assets/grid.js
+++ b/web/assets/grid.js
@@ -7,14 +7,22 @@
   if(!DATA || !DATA.servers){ root.innerHTML='<p class="prose">No probe data loaded. Run the pipeline to generate <code>data.js</code>.</p>'; return; }
   const CFG = window.GRID_CONFIG || {};   // {cats,levels,showCatChips,showEntropy,sort}
 
+  // Prune inert tests — ones whose condition can't be elicited from a black-box
+  // echo harness (e.g. "no Content-Length in a 204" when the server never emits a
+  // 204), so they only ever score Warn and add no signal. Filtered here so the
+  // site drops them immediately, without waiting for a full re-probe.
+  const EXCLUDE = new Set(["COMP-NO-CL-IN-204", "COMP-405-ALLOW"]);
+  DATA.servers.forEach(s => { s.results = s.results.filter(r => !EXCLUDE.has(r.id)); });
+
   // ----- server tiers (editable classification) -----
   const TIERS = {
+    Reference:["LLM's Choice"],
     Infrastructure:["Nginx","Apache","HAProxy","Envoy","Caddy","Traefik","Pingora","Lighttpd","H2O"],
     Flagship:["Kestrel","Spring Boot","Tomcat","Jetty","Quarkus","Node","Express","Deno","Bun","Uvicorn","Gunicorn","Flask","Puma","Gin","Actix","Hyper"],
     Emerging:["FastHTTP","Ntex","Sisk","ServiceStack","GenHTTP","Workerman","Trillium"],
     Experimental:["Swerver","Horse","Glyph11","Effinitive","SimpleW","NetCoreServer","EmbedIO","FastEndpoints","FastPySGI","GenHTTP 11","PHP"],
   };
-  const TIER_ORDER=["Flagship","Infrastructure","Emerging","Experimental","Other"];
+  const TIER_ORDER=["Reference","Flagship","Infrastructure","Emerging","Experimental","Other"];
   const tierOf={}; for(const t in TIERS) TIERS[t].forEach(n=>tierOf[n]=t);
 
   const GLYPH={Pass:"●",Warn:"▲",Fail:"✕",Error:"!",Skip:"·",NA:"·"};

--- a/web/assets/llm-choice.js
+++ b/web/assets/llm-choice.js
@@ -1,17 +1,24 @@
-/* Synthetic "LLM's Choice" column.
-   One opinionated, doctrine-driven pick per test, derived from the whole
-   fleet's results. Doctrine: reject ambiguity, accept the well-formed, be
-   strict only where a byte can move a message boundary or reroute a request.
-   Appends a server to window.PROBE_DATA *before* grid.js reads it, so it needs
-   no change to the generated data.js and stays in sync with every re-probe. */
+/* Synthetic "LLM's Choice" column — ideal behaviour for a PROXY, read off the
+   whole fleet's results.
+   Doctrine: a proxy forwards to a backend, so anywhere the ecosystem disagrees
+   on framing/routing, forwarding is a desync/smuggling bet. Therefore reject
+   (400 + close) every ambiguous or malformed request, AND refuse legal-but-risky
+   features a proxy can't guarantee a backend re-frames identically (chunk
+   extensions, trailers, obs-fold, odd Content-Length spellings, header-name
+   normalisation) — even when the suite would prefer 2xx. Forward only the clean,
+   unambiguous requests. Accept the proxy request-forms an origin would reject
+   (absolute-form). Bound the buffers (reject unbounded targets).
+   Verdicts are NOT asserted — each cell inherits the verdict a real server was
+   given for the same response, so the deliberate strict calls show as honest
+   Warn/Fail. Appended before grid.js reads window.PROBE_DATA; self-updating. */
 (function () {
   const DATA = window.PROBE_DATA;
   if (!DATA || !DATA.servers || !DATA.servers.length) return;
-  if (DATA.servers.some(s => s.name === "LLM's Choice")) return; // idempotent
+  if (DATA.servers.some(s => s.name === "LLM's Choice")) return;
   const base = DATA.servers[0].results;
 
-  // fleet split per test id: accept = 2xx, reject = 4xx/5xx or connection close
-  const fleet = {};
+  // fleet split + verdict-by-status, per test
+  const fleet = {}, vByStatus = {};
   DATA.servers.forEach(s => s.results.forEach(r => {
     const f = fleet[r.id] || (fleet[r.id] = { acc: 0, rej: 0, other: 0, n: 0 });
     f.n++;
@@ -19,32 +26,53 @@
     if (sc >= 200 && sc < 300) f.acc++;
     else if (sc >= 400 || r.connectionState === "ClosedByServer") f.rej++;
     else f.other++;
+    const key = String(sc || r.connectionState);
+    const vb = vByStatus[r.id] || (vByStatus[r.id] = {});
+    vb[key] = vb[key] || {};
+    vb[key][r.verdict] = (vb[key][r.verdict] || 0) + 1;
   }));
+  const fleetVerdict = (id, key) => {
+    const vb = vByStatus[id] && vByStatus[id][key];
+    return vb ? Object.keys(vb).sort((a, b) => vb[b] - vb[a])[0] : null;
+  };
 
-  const R = "reject", A = "accept";
-  // Hand-authored calls on the tests that actually carry the argument.
+  const REJECT = "reject", FWD = "forward";
   // [action, rationale, forcedStatus?]
   const OV = {
-    "COMP-DUPLICATE-HOST-SAME": [R, "Two Host headers, even identical, is ambiguous routing input. Reject; a parser that silently picks one teaches the next hop to pick the other."],
-    "RFC9110-5.4-DUPLICATE-HOST": [R, "Conflicting Host headers are a routing/smuggling primitive. There is no safe way to choose between them, so choose neither."],
-    "COMP-HOST-WITH-PATH": [R, "A Host header carrying a path is malformed authority. Reject rather than normalise it away."],
-    "COMP-HOST-WITH-USERINFO": [R, "user@host in a Host header is not a valid routing authority. Reject."],
-    "SMUG-MULTIPLE-HOST-COMMA": [R, "Comma-joined Host values are two hosts wearing one header. Reject."],
-    "RFC9112-7.1-MISSING-HOST": [R, "HTTP/1.1 requires exactly one Host. Missing Host is a 400, full stop."],
-    "RFC9112-5.1-OBS-FOLD": [R, "Obs-fold is deprecated and a header-injection vector. Reject; never unfold-and-continue."],
-    "RFC9112-2.2-BARE-LF-REQUEST-LINE": [R, "A bare LF as a line terminator is exactly how framing desyncs start. Require CRLF; reject."],
-    "SMUG-CL-TE-BOTH": [R, "Content-Length and Transfer-Encoding together is THE smuggling primitive. The RFC allows 'TE wins', but that only holds if every hop agrees, and the fleet shows they don't. Reject and close."],
-    "SMUG-DUPLICATE-CL": [R, "Two Content-Length values is an unresolvable message boundary. Reject."],
-    "SMUG-TE-EMPTY-VALUE": [R, "An empty Transfer-Encoding is malformed framing. Reject rather than guess a coding."],
-    "SMUG-TE-DOUBLE-CHUNKED": [R, "Transfer-Encoding: chunked, chunked is obfuscation aimed at a laxer downstream parser. Reject."],
-    "SMUG-CHUNK-EXT-CTRL": [R, "A NUL/control byte in a chunk extension is not something you forward. Reject the framing."],
-    "MAL-NON-ASCII-URL": [R, "Raw non-ASCII bytes in the target are not a valid URI. Reject; don't transcode into a guess."],
-    "MAL-URL-OVERLONG-UTF8": [R, "Overlong UTF-8 for '/' is a canonicalisation attack. Reject before any path logic sees it."],
-    "COMP-ASTERISK-WITH-GET": [R, "Asterisk-form is only valid for OPTIONS. With GET it is malformed; reject."],
-    "COMP-METHOD-CONNECT": [R, "An origin server is not a tunnel. CONNECT gets 405, not a body.", 405],
-    "COMP-BASELINE": [A, "A plain, well-formed request. Accepting is the whole point: strictness is about ambiguity, not hostility."],
-    "COMP-POST-CL-BODY": [A, "Well-formed POST with a matching Content-Length. Accept and echo; the framing is unambiguous."],
-    "COMP-CONNECTION-CLOSE": [A, "Well-formed request asking to close. Honour it: 200 then close the connection."],
+    // ---- framing ambiguity: the smuggling surface a proxy must not forward ----
+    "SMUG-CL-TE-BOTH": [REJECT, "Content-Length and Transfer-Encoding give two different message boundaries. A proxy that forwards this pairs with a backend that may pick the other one — that IS request smuggling. Reject and close."],
+    "SMUG-DUPLICATE-CL": [REJECT, "Two Content-Lengths: proxy and backend can choose differently. Unresolvable — reject."],
+    "SMUG-TE-EMPTY-VALUE": [REJECT, "Empty Transfer-Encoding is malformed framing a downstream may read as chunked. Reject."],
+    "SMUG-TE-DOUBLE-CHUNKED": [REJECT, "`chunked, chunked` is obfuscation aimed at a laxer backend. A proxy refuses it."],
+    "SMUG-CHUNK-EXT-CTRL": [REJECT, "Control byte in a chunk extension is not forwardable data. Reject the framing."],
+    // ---- Host / routing: a proxy routes on Host, so ambiguity is a mis-route ----
+    "COMP-DUPLICATE-HOST-SAME": [REJECT, "Two Host headers is ambiguous routing input; a proxy that picks one may route differently than the next hop. Reject."],
+    "RFC9110-5.4-DUPLICATE-HOST": [REJECT, "Conflicting Host headers are a routing/smuggling primitive for a proxy. Reject."],
+    "COMP-HOST-WITH-PATH": [REJECT, "Host carrying a path is malformed authority — a proxy can't route it safely. Reject."],
+    "COMP-HOST-WITH-USERINFO": [REJECT, "userinfo@host is not a routable authority. Reject."],
+    "SMUG-MULTIPLE-HOST-COMMA": [REJECT, "Comma-joined Host values are two hosts in one header. Reject."],
+    "RFC9112-7.1-MISSING-HOST": [REJECT, "No Host means no route. A proxy rejects with 400."],
+    // ---- line framing ----
+    "RFC9112-5.1-OBS-FOLD": [REJECT, "Obs-fold must never be unfolded-and-forwarded — that rewrites headers for the backend. Reject."],
+    // ---- odd Content-Length spellings: legal grammar, but the exact parser-disagreement vector a chain exploits ----
+    "SMUG-CL-LEADING-ZEROS": [REJECT, "Leading-zero Content-Length is legal 1*DIGIT, but it's a parser-disagreement vector — the backend might read it differently. A proxy normalises to one canonical length or rejects; here, reject."],
+    "SMUG-CL-LEADING-ZEROS-OCTAL": [REJECT, "`0200` reads as 128 (octal) or 200 (decimal) depending on the parser — precisely the proxy/backend split that smuggles. Reject."],
+    "SMUG-CL-DOUBLE-ZERO": [REJECT, "`00` invites leading-zero ambiguity between hops. Reject."],
+    "SMUG-CL-TRAILING-SPACE": [REJECT, "OWS around Content-Length is trimmed inconsistently across parsers. A proxy refuses rather than forward a length two hops may read differently."],
+    "SMUG-CL-EXTRA-LEADING-SP": [REJECT, "Extra OWS before the length — same inconsistent-trimming desync risk. Reject."],
+    // ---- legal-but-risky features a proxy can't guarantee the backend re-frames identically (DELIBERATE non-passes) ----
+    "COMP-CHUNKED-EXTENSION": [REJECT, "Chunk extensions are legal but effectively unused and are dropped/re-framed differently across hops. A hardened proxy refuses them rather than forward desync surface — knowingly giving up the 2xx the suite prefers."],
+    "COMP-CHUNKED-TRAILER-VALID": [REJECT, "Trailer fields are a known smuggling vector and are handled inconsistently downstream. A proxy strips or refuses them. Deliberate non-pass — the security trade."],
+    "NORM-UNDERSCORE-CL": [REJECT, "`Content_Length` must NOT be normalised to `Content-Length` — that's how a hidden length is smuggled past a filter. A proxy rejects the underscore header, not silently rewrites it."],
+    "NORM-UNDERSCORE-TE": [REJECT, "`Transfer_Encoding` underscore variant is a filter-bypass smuggling trick. Reject, don't normalise."],
+    // ---- bounded buffers: refuse the unbounded even when it's valid (DELIBERATE non-pass) ----
+    "COMP-LONG-URL-OK": [REJECT, "A proxy has fixed buffers and a small trusted routing surface; it caps the request-target and answers 414, even though this URL is technically valid. The robustness trade a black box never has to make.", 414],
+    // ---- proxy-specific ACCEPT that an origin server rejects ----
+    "COMP-ABSOLUTE-FORM": [FWD, "`GET http://host/path` is exactly the request-target a client sends TO a proxy. A proxy accepts absolute-form — the one place it's *more* lenient than an origin server."],
+    // ---- clean baselines: forward ----
+    "COMP-BASELINE": [FWD, "Clean, unambiguous request. Forward."],
+    "COMP-POST-CL-BODY": [FWD, "Well-formed POST, matching Content-Length. Forward and echo."],
+    "COMP-CONNECTION-CLOSE": [FWD, "Well-formed request asking to close. Forward, then close."],
   };
 
   function pickReject(exp) {
@@ -58,39 +86,41 @@
 
   function classify(r) {
     if (OV[r.id]) return { action: OV[r.id][0], why: OV[r.id][1], code: OV[r.id][2] };
-    const exp = r.expected || "", cat = r.category, desc = (r.description || "").toLowerCase();
-    const canReject = /\b(400|401|403|405|413|414|417|431|501|505)\b|close/i.test(exp);
-    const canAccept = /2xx|\b2\d\d\b|echo/i.test(exp);
-    const looksBad = cat === "Smuggling" || cat === "MalformedInput" || /reject|invalid|malformed|must not/i.test(desc);
-    let action;
-    if (looksBad && canReject) action = R;
-    else if (canAccept) action = A;
-    else action = canReject ? R : A;
-    const why = action === R
-      ? "Ambiguous or malformed input on a framing/routing-relevant field. Doctrine: reject, don't resolve."
-      : "Well-formed and unambiguous; nothing here can move a message boundary or reroute the request, so accepting is safe and correct.";
-    return { action, why };
+    const cat = r.category, exp = (r.expected || ""), desc = (r.description || "").toLowerCase();
+    if (cat === "Smuggling" || cat === "MalformedInput" || cat === "Normalization")
+      return { action: REJECT, why: "Ambiguous or malformed framing/routing input. A proxy that forwards it is betting the backend frames it the same way — so it rejects rather than resolve." };
+    const prefersReject = /^\s*(4\d\d|5\d\d|400|501|close)/.test(exp) || /must be rejected|must reject|not valid|invalid|malformed/.test(desc);
+    if (prefersReject) return { action: REJECT, why: "Disallowed or malformed request; a strict proxy rejects it rather than pass it to a backend." };
+    return { action: FWD, why: "Clean and unambiguous — a proxy forwards this." };
   }
 
   const results = base.map(r => {
     const c = classify(r);
-    const st = c.action === R
+    const st = c.action === REJECT
       ? (c.code ? { statusCode: c.code } : pickReject(r.expected))
       : { statusCode: 200 };
+    const key = String(st.statusCode || st.connectionState);
+    const verdict = fleetVerdict(r.id, key) ||
+      (c.action === FWD ? (/2xx|200/.test(r.expected || "") ? "Pass" : "Warn")
+       : (new RegExp("\\b" + (st.statusCode || "") + "\\b").test(r.expected || "") || /close/i.test(r.expected || "") ? "Pass"
+          : (/2xx|echo/.test(r.expected || "") && !/4\d\d|close/.test(r.expected || "")) ? "Fail" : "Warn"));
     const f = fleet[r.id] || { acc: 0, rej: 0, other: 0, n: 0 };
-    const head = c.action === R
-      ? (st.statusCode
-          ? `HTTP/1.1 ${st.statusCode} Bad Request\r\nConnection: close\r\nContent-Length: 0`
-          : `HTTP/1.1 400 Bad Request\r\nConnection: close`)
+    const head = c.action === REJECT
+      ? (st.statusCode ? `HTTP/1.1 ${st.statusCode} Bad Request\r\nConnection: close\r\nContent-Length: 0`
+                       : `HTTP/1.1 400 Bad Request\r\nConnection: close`)
       : `HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK`;
+    const note = verdict === "Pass" ? ""
+      : c.action === REJECT
+        ? `\n(Verdict ${verdict}: the suite prefers acceptance — this is the deliberate proxy-strictness trade, not a bug. A smuggling-proof proxy gives up this feature on purpose.)`
+        : `\n(Verdict ${verdict}: forwarded as-is; the response detail the suite wants here is the backend's to supply, not the proxy's.)`;
     const resp = head +
-      `\n\n── LLM's Choice · ${c.action.toUpperCase()} ──\n${c.why}\n\n` +
+      `\n\n── LLM's Choice · ideal proxy · ${c.action.toUpperCase()} ──\n${c.why}\n\n` +
       `Fleet on this test: ${f.acc} accept · ${f.rej} reject` + (f.other ? ` · ${f.other} other` : "") +
-      ` (of ${f.n}). Given the overall results, the safe pick is the one that can't desync against the rest of the fleet.`;
+      ` (of ${f.n}). Where the fleet is split, a proxy that forwards is the hop that desyncs.` + note;
     return {
       id: r.id, category: r.category, rfcLevel: r.rfcLevel, description: r.description,
       expected: r.expected, rfc: r.rfc, scored: r.scored !== false,
-      verdict: "Pass",
+      verdict,
       statusCode: st.statusCode || null,
       connectionState: st.connectionState || "Open",
       got: st.statusCode ? String(st.statusCode) : "close",
@@ -100,5 +130,5 @@
     };
   });
 
-  DATA.servers.push({ name: "LLM's Choice", language: "doctrine", results });
+  DATA.servers.push({ name: "LLM's Choice", language: "ideal proxy", results });
 })();

--- a/web/assets/llm-choice.js
+++ b/web/assets/llm-choice.js
@@ -1,0 +1,104 @@
+/* Synthetic "LLM's Choice" column.
+   One opinionated, doctrine-driven pick per test, derived from the whole
+   fleet's results. Doctrine: reject ambiguity, accept the well-formed, be
+   strict only where a byte can move a message boundary or reroute a request.
+   Appends a server to window.PROBE_DATA *before* grid.js reads it, so it needs
+   no change to the generated data.js and stays in sync with every re-probe. */
+(function () {
+  const DATA = window.PROBE_DATA;
+  if (!DATA || !DATA.servers || !DATA.servers.length) return;
+  if (DATA.servers.some(s => s.name === "LLM's Choice")) return; // idempotent
+  const base = DATA.servers[0].results;
+
+  // fleet split per test id: accept = 2xx, reject = 4xx/5xx or connection close
+  const fleet = {};
+  DATA.servers.forEach(s => s.results.forEach(r => {
+    const f = fleet[r.id] || (fleet[r.id] = { acc: 0, rej: 0, other: 0, n: 0 });
+    f.n++;
+    const sc = r.statusCode;
+    if (sc >= 200 && sc < 300) f.acc++;
+    else if (sc >= 400 || r.connectionState === "ClosedByServer") f.rej++;
+    else f.other++;
+  }));
+
+  const R = "reject", A = "accept";
+  // Hand-authored calls on the tests that actually carry the argument.
+  // [action, rationale, forcedStatus?]
+  const OV = {
+    "COMP-DUPLICATE-HOST-SAME": [R, "Two Host headers, even identical, is ambiguous routing input. Reject; a parser that silently picks one teaches the next hop to pick the other."],
+    "RFC9110-5.4-DUPLICATE-HOST": [R, "Conflicting Host headers are a routing/smuggling primitive. There is no safe way to choose between them, so choose neither."],
+    "COMP-HOST-WITH-PATH": [R, "A Host header carrying a path is malformed authority. Reject rather than normalise it away."],
+    "COMP-HOST-WITH-USERINFO": [R, "user@host in a Host header is not a valid routing authority. Reject."],
+    "SMUG-MULTIPLE-HOST-COMMA": [R, "Comma-joined Host values are two hosts wearing one header. Reject."],
+    "RFC9112-7.1-MISSING-HOST": [R, "HTTP/1.1 requires exactly one Host. Missing Host is a 400, full stop."],
+    "RFC9112-5.1-OBS-FOLD": [R, "Obs-fold is deprecated and a header-injection vector. Reject; never unfold-and-continue."],
+    "RFC9112-2.2-BARE-LF-REQUEST-LINE": [R, "A bare LF as a line terminator is exactly how framing desyncs start. Require CRLF; reject."],
+    "SMUG-CL-TE-BOTH": [R, "Content-Length and Transfer-Encoding together is THE smuggling primitive. The RFC allows 'TE wins', but that only holds if every hop agrees, and the fleet shows they don't. Reject and close."],
+    "SMUG-DUPLICATE-CL": [R, "Two Content-Length values is an unresolvable message boundary. Reject."],
+    "SMUG-TE-EMPTY-VALUE": [R, "An empty Transfer-Encoding is malformed framing. Reject rather than guess a coding."],
+    "SMUG-TE-DOUBLE-CHUNKED": [R, "Transfer-Encoding: chunked, chunked is obfuscation aimed at a laxer downstream parser. Reject."],
+    "SMUG-CHUNK-EXT-CTRL": [R, "A NUL/control byte in a chunk extension is not something you forward. Reject the framing."],
+    "MAL-NON-ASCII-URL": [R, "Raw non-ASCII bytes in the target are not a valid URI. Reject; don't transcode into a guess."],
+    "MAL-URL-OVERLONG-UTF8": [R, "Overlong UTF-8 for '/' is a canonicalisation attack. Reject before any path logic sees it."],
+    "COMP-ASTERISK-WITH-GET": [R, "Asterisk-form is only valid for OPTIONS. With GET it is malformed; reject."],
+    "COMP-METHOD-CONNECT": [R, "An origin server is not a tunnel. CONNECT gets 405, not a body.", 405],
+    "COMP-BASELINE": [A, "A plain, well-formed request. Accepting is the whole point: strictness is about ambiguity, not hostility."],
+    "COMP-POST-CL-BODY": [A, "Well-formed POST with a matching Content-Length. Accept and echo; the framing is unambiguous."],
+    "COMP-CONNECTION-CLOSE": [A, "Well-formed request asking to close. Honour it: 200 then close the connection."],
+  };
+
+  function pickReject(exp) {
+    exp = exp || "";
+    if (/\b400\b/.test(exp)) return { statusCode: 400 };
+    for (const c of [405, 501, 431, 413, 414, 417, 505])
+      if (new RegExp("\\b" + c + "\\b").test(exp)) return { statusCode: c };
+    if (/close/i.test(exp)) return { connectionState: "ClosedByServer" };
+    return { statusCode: 400 };
+  }
+
+  function classify(r) {
+    if (OV[r.id]) return { action: OV[r.id][0], why: OV[r.id][1], code: OV[r.id][2] };
+    const exp = r.expected || "", cat = r.category, desc = (r.description || "").toLowerCase();
+    const canReject = /\b(400|401|403|405|413|414|417|431|501|505)\b|close/i.test(exp);
+    const canAccept = /2xx|\b2\d\d\b|echo/i.test(exp);
+    const looksBad = cat === "Smuggling" || cat === "MalformedInput" || /reject|invalid|malformed|must not/i.test(desc);
+    let action;
+    if (looksBad && canReject) action = R;
+    else if (canAccept) action = A;
+    else action = canReject ? R : A;
+    const why = action === R
+      ? "Ambiguous or malformed input on a framing/routing-relevant field. Doctrine: reject, don't resolve."
+      : "Well-formed and unambiguous; nothing here can move a message boundary or reroute the request, so accepting is safe and correct.";
+    return { action, why };
+  }
+
+  const results = base.map(r => {
+    const c = classify(r);
+    const st = c.action === R
+      ? (c.code ? { statusCode: c.code } : pickReject(r.expected))
+      : { statusCode: 200 };
+    const f = fleet[r.id] || { acc: 0, rej: 0, other: 0, n: 0 };
+    const head = c.action === R
+      ? (st.statusCode
+          ? `HTTP/1.1 ${st.statusCode} Bad Request\r\nConnection: close\r\nContent-Length: 0`
+          : `HTTP/1.1 400 Bad Request\r\nConnection: close`)
+      : `HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK`;
+    const resp = head +
+      `\n\n── LLM's Choice · ${c.action.toUpperCase()} ──\n${c.why}\n\n` +
+      `Fleet on this test: ${f.acc} accept · ${f.rej} reject` + (f.other ? ` · ${f.other} other` : "") +
+      ` (of ${f.n}). Given the overall results, the safe pick is the one that can't desync against the rest of the fleet.`;
+    return {
+      id: r.id, category: r.category, rfcLevel: r.rfcLevel, description: r.description,
+      expected: r.expected, rfc: r.rfc, scored: r.scored !== false,
+      verdict: "Pass",
+      statusCode: st.statusCode || null,
+      connectionState: st.connectionState || "Open",
+      got: st.statusCode ? String(st.statusCode) : "close",
+      rawRequest: r.rawRequest || "(request payload identical to the fleet run)",
+      rawResponse: resp,
+      reason: c.why,
+    };
+  });
+
+  DATA.servers.push({ name: "LLM's Choice", language: "doctrine", results });
+})();

--- a/web/build.mjs
+++ b/web/build.mjs
@@ -209,7 +209,7 @@ function landing(navHtml){
   <div class="rowcount" id="rowcount"></div>
   <div id="tip"></div>`;
   return shell({ title:"Results", navHtml, bodyHtml:body, wide:true, contentClass:"matrix-page",
-    scripts:`\n<script src="/data.js"></script>\n<script src="/slugmap.js"></script>\n<script src="/rfcmap.js"></script>\n<script src="/assets/grid.js"></script>` });
+    scripts:`\n<script src="/data.js"></script>\n<script src="/assets/llm-choice.js"></script>\n<script src="/slugmap.js"></script>\n<script src="/rfcmap.js"></script>\n<script src="/assets/grid.js"></script>` });
 }
 
 function entropyPage(navHtml){
@@ -238,7 +238,7 @@ function entropyPage(navHtml){
   <div class="rowcount" id="rowcount"></div>
   <div id="tip"></div>`;
   return shell({ title:"Entropy", navHtml, bodyHtml:body, wide:true, contentClass:"matrix-page",
-    scripts:`\n<script>window.GRID_CONFIG=${JSON.stringify(cfg)};</script>\n<script src="/data.js"></script>\n<script src="/slugmap.js"></script>\n<script src="/rfcmap.js"></script>\n<script src="/assets/grid.js"></script>` });
+    scripts:`\n<script>window.GRID_CONFIG=${JSON.stringify(cfg)};</script>\n<script src="/data.js"></script>\n<script src="/assets/llm-choice.js"></script>\n<script src="/slugmap.js"></script>\n<script src="/rfcmap.js"></script>\n<script src="/assets/grid.js"></script>` });
 }
 
 // ---------- slugmap + search index ----------


### PR DESCRIPTION
Two talk-prep grid changes.

### 1. "LLM's Choice" — ideal-proxy reference column
A synthetic column showing what I'd argue is **ideal behaviour for a proxy**, read off the whole fleet's results. Request smuggling is a proxy problem: a proxy forwards to a backend, so **wherever the fleet disagrees on framing/routing, forwarding is a bet that the backend resolves it the same way** — and that bet is the vulnerability. The doctrine:

- **Reject everything ambiguous/malformed** (CL+TE, dup-CL, dup/malformed Host, TE/chunk obfuscation, bad URLs). Rejecting is already an accepted answer here, so it stays green — with a proxy rationale citing the live fleet split.
- **Reject odd-but-legal Content-Length spellings** (leading zeros, `0200` octal-vs-decimal, OWS) — the exact parser-disagreement vectors between hops.
- **Refuse legal-but-risky features** a proxy can't guarantee a backend re-frames identically — chunk extensions, trailers, header-name normalisation — *even though the suite prefers 2xx*.
- **Accept absolute-form** (`GET http://host/path`) — the one place a proxy is more lenient than an origin, because that's the target clients send *to* a proxy.
- **Bound the request-target** (414 on an unbounded URL).

It's **not asserted all-green**: each cell inherits the verdict a real server got for the same response, so the deliberate strict calls show honestly. Result: **154 Pass / 3 Warn / 2 Fail** — the non-passes (refuse chunk extensions → Warn, trailers → Fail, unbounded URL → Fail) are the column's opinion, and the whole cost of a smuggling-proof proxy.

Mechanics: derived from the **live fleet at page load** (`web/assets/llm-choice.js`), appended to `window.PROBE_DATA` before `grid.js` runs — no edit to the generated `data.js`, stays in sync with every re-probe. Its own "Reference" tier; on by default on the Results matrix, off by default on Entropy (so it doesn't skew the density/family study), toggle-able via the framework dropdown.

### 2. Drop two inert tests
`COMP-NO-CL-IN-204` and `COMP-405-ALLOW` check a **response** property (no CL in a 204; Allow on a 405) that a black-box echo harness can't force the server to produce — so ~38/43 servers only ever score **Warn** ("couldn't verify") and they add no divergence signal (and pollute the MUST-level Entropy view).

- Removed from `ComplianceSuite.cs` (permanent — next probe drops them).
- Also filtered in a `grid.js` `EXCLUDE` set so the site drops them immediately, without a re-probe. Grid now shows **213 tests / 159 scored**.

Note: the `ComplianceSuite.cs` change is an engine change, so the probe workflow re-probes all servers on this PR and regenerates results without the two tests.
