### PR TITLE
site: syntax highlighting, per-server test results, mobile grid scroll

### DIFF
--- a/web/assets/styles.css
+++ b/web/assets/styles.css
@@ -122,6 +122,19 @@ code,.mono{font-family:var(--mono)}
 .prose pre{background:var(--surface-2);border:1px solid var(--line-2);border-radius:0;padding:15px 17px;
   overflow-x:auto;margin:0 0 16px;font-size:13px;line-height:1.55}
 .prose pre code{background:none;border:0;padding:0;font-size:13px;white-space:pre}
+/* ---- syntax highlighting (highlight.js tokens, theme-aware) ---- */
+:root{--hl-com:#6a737d;--hl-kw:#cf222e;--hl-str:#0a3069;--hl-num:#0550ae;--hl-type:#953800;--hl-fn:#6639ba;--hl-attr:#116329}
+@media (prefers-color-scheme:dark){:root{--hl-com:#8b949e;--hl-kw:#ff7b72;--hl-str:#a5d6ff;--hl-num:#79c0ff;--hl-type:#ffa657;--hl-fn:#d2a8ff;--hl-attr:#7ee787}}
+:root[data-theme="dark"]{--hl-com:#8b949e;--hl-kw:#ff7b72;--hl-str:#a5d6ff;--hl-num:#79c0ff;--hl-type:#ffa657;--hl-fn:#d2a8ff;--hl-attr:#7ee787}
+:root[data-theme="light"]{--hl-com:#6a737d;--hl-kw:#cf222e;--hl-str:#0a3069;--hl-num:#0550ae;--hl-type:#953800;--hl-fn:#6639ba;--hl-attr:#116329}
+.hljs-comment,.hljs-quote{color:var(--hl-com);font-style:italic}
+.hljs-keyword,.hljs-selector-tag,.hljs-literal,.hljs-doctag,.hljs-section,.hljs-name,.hljs-deletion{color:var(--hl-kw)}
+.hljs-string,.hljs-regexp,.hljs-addition,.hljs-attribute,.hljs-meta .hljs-string,.hljs-char.escape_{color:var(--hl-str)}
+.hljs-number,.hljs-symbol,.hljs-bullet,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo,.hljs-template-tag{color:var(--hl-num)}
+.hljs-built_in,.hljs-type,.hljs-class .hljs-title,.hljs-title.class_,.hljs-meta{color:var(--hl-type)}
+.hljs-title,.hljs-title.function_,.hljs-function .hljs-title{color:var(--hl-fn)}
+.hljs-attr,.hljs-variable,.hljs-template-variable,.hljs-property,.hljs-params,.hljs-tag{color:var(--hl-attr)}
+.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:700}
 .prose table{border-collapse:collapse;width:auto;max-width:100%;margin:0 0 18px;font-size:14px;display:block;overflow-x:auto}
 .prose th,.prose td{border:1px solid var(--line-2);padding:8px 13px;text-align:left;vertical-align:top}
 .prose th{background:var(--surface-2);font-weight:640;font-size:13px}
@@ -155,9 +168,15 @@ code,.mono{font-family:var(--mono)}
   .menu-toggle{display:inline-block}
   .topbar .nav-links{display:none}
   .search input{width:130px}
-  .main{max-width:none}
+  .main{max-width:none;padding-left:12px;padding-right:12px}
   .scrim{display:none;position:fixed;inset:var(--topbar-h) 0 0;background:rgba(0,0,0,.4);z-index:34}
   body.nav-open .scrim{display:block}
+  /* mobile grid: keep the horizontal swipe inside the matrix, and shrink the
+     sticky test-name column so a narrow screen has room to slide the cells */
+  body{overflow-x:clip}
+  th.corner,td.rid{min-width:150px;max-width:150px}
+  .matrix.we th.corner,.matrix.we td.rid{min-width:132px;max-width:132px}
+  .matrix.we th.ent-h,.matrix.we td.ent{left:132px}
 }
 @media (prefers-reduced-motion:reduce){*{transition:none!important;scroll-behavior:auto!important}}
 
@@ -208,7 +227,8 @@ code,.mono{font-family:var(--mono)}
 .fw-opt .lg{color:var(--muted);font-family:var(--mono);font-size:10px;margin-left:auto}
 
 /* matrix */
-.matrix-scroll{overflow:auto;border:1px solid var(--line-2);border-radius:0;background:var(--surface);
+.matrix-scroll{overflow:auto;-webkit-overflow-scrolling:touch;overscroll-behavior:contain;
+  border:1px solid var(--line-2);border-radius:0;background:var(--surface);
   max-height:80vh;box-shadow:var(--shadow)}
 table.matrix{display:table;border-collapse:separate;border-spacing:0;font-family:var(--mono);font-size:12px}
 th.corner{position:sticky;left:0;top:0;z-index:6;background:var(--surface-2);text-align:left;padding:0 12px;

--- a/web/build.mjs
+++ b/web/build.mjs
@@ -5,6 +5,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 const require = createRequire(import.meta.url);
 const MarkdownIt = require("markdown-it");
+const hljs = require("highlight.js");
 
 const __dir = path.dirname(fileURLToPath(import.meta.url));
 const CONTENT = path.resolve(__dir, "../docs/content");
@@ -12,7 +13,20 @@ const DIST = path.resolve(__dir, "dist");
 const ASSETS = path.resolve(__dir, "assets");
 const GH = "https://github.com/MDA2AV/Http11Probe";
 
-const md = new MarkdownIt({ html: true, linkify: true, breaks: false });
+const md = new MarkdownIt({
+  html: true, linkify: true, breaks: false,
+  highlight(str, lang){
+    const alias = { jsp: "xml", cs: "csharp", "c++": "cpp", plaintext: "", text: "" };
+    const l = alias[lang] ?? lang;
+    if (l && hljs.getLanguage(l)) {
+      try {
+        const out = hljs.highlight(str, { language: l, ignoreIllegals: true }).value;
+        return `<pre class="hljs"><code class="hljs language-${l}">${out}</code></pre>`;
+      } catch {}
+    }
+    return `<pre class="hljs"><code>${md.utils.escapeHtml(str)}</code></pre>`;
+  }
+});
 
 // ---------- helpers ----------
 const read = p => fs.readFileSync(p, "utf8");
@@ -304,6 +318,12 @@ function main(){
   const src=dataCandidates.find(exists);
   if(src) fs.copyFileSync(src, path.join(DIST,"data.js"));
   else fs.writeFileSync(path.join(DIST,"data.js"),"window.PROBE_DATA={servers:[]};");
+  // per-server pages (servers/*.html) load /probe/data.js + /probe/render.js (the ProbeRender lib)
+  const probeDst=path.join(DIST,"probe"); fs.mkdirSync(probeDst,{recursive:true});
+  if(src) fs.copyFileSync(src, path.join(probeDst,"data.js"));
+  else fs.writeFileSync(path.join(probeDst,"data.js"),"window.PROBE_DATA={servers:[]};");
+  const renderSrc=path.resolve(__dir,"../docs/static/probe/render.js");
+  if(exists(renderSrc)) fs.copyFileSync(renderSrc, path.join(probeDst,"render.js"));
   // GitHub Pages custom domain (keeps www.http-probe.com pointed at this deploy)
   fs.writeFileSync(path.join(DIST,"CNAME"), "www.http-probe.com\n");
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "highlight.js": "^11.11.1",
         "markdown-it": "^14.3.0"
       }
     },
@@ -26,6 +27,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/linkify-it": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "highlight.js": "^11.11.1",
     "markdown-it": "^14.3.0"
   }
 }


### PR DESCRIPTION
Three site fixes, all in `web/`.

### Syntax highlighting
Code blocks on the site had no highlighting. Wired **highlight.js** into markdown-it's `highlight` hook so code is highlighted **at build time** (static HTML, no runtime JS, works with JS off). Covers every language the pages use — C#, Go, Rust, Python, Java, JS/TS, PHP, Ruby, Dockerfile, YAML, bash. Token colours are theme-aware CSS variables, so they follow the site's light/dark toggle.

### Per-server "Test Results" section was empty
Server pages (`docs/content/servers/*`) load `/probe/data.js` + `/probe/render.js` and call `ProbeRender.renderServerPage(...)` — Hugo-era wiring. The new `web/` build only emitted `/data.js` and had no `render.js`, so both 404'd and the section stayed empty. The build now also emits `/probe/data.js` and copies the existing `render.js` to `/probe/render.js`. Verified: `renderServerPage('Kestrel')` renders the summary bar (127 pass · 20 warn · 14 fail · 54 unscored) + per-category tables.

### Mobile grid scroll
The results/entropy matrices couldn't be swiped horizontally on phones. `overscroll-behavior:contain` keeps the swipe inside the grid (mobile browsers were hijacking it as a back-gesture), `overflow-x:clip` stops the whole page from sliding, and the 320 px sticky test-name column shrinks on ≤920 px so there's room to scroll.

Adds `highlight.js` as a dependency (CI's `npm ci` picks it up).