### PR TITLE
Raise the response read buffer to 128KiB

### DIFF
--- a/src/Http11Probe/Client/RawTcpClient.cs
+++ b/src/Http11Probe/Client/RawTcpClient.cs
@@ -5,6 +5,12 @@ namespace Http11Probe.Client;
 
 public sealed class RawTcpClient : IAsyncDisposable
 {
+    // Responses are read into a single fixed buffer and truncated at its size. Keep this above the
+    // largest payload any test sends — 100,000 bytes (MAL-LONG-URL, MAL-LONG-HEADER-NAME,
+    // MAL-LONG-HEADER-VALUE, MAL-LONG-METHOD) — so a server that echoes one back in an error
+    // response doesn't get cut off and misread as a truncated reply.
+    private const int ReadBufferSize = 128 * 1024;
+
     private Socket? _socket;
     private readonly TimeSpan _connectTimeout;
     private readonly TimeSpan _readTimeout;
@@ -60,7 +66,7 @@ public sealed class RawTcpClient : IAsyncDisposable
         if (_socket is null)
             return ([], 0, ConnectionState.Error, false);
 
-        var buffer = new byte[65536];
+        var buffer = new byte[ReadBufferSize];
         var totalRead = 0;
 
         using var cts = new CancellationTokenSource(_readTimeout);


### PR DESCRIPTION
`RawTcpClient.ReadResponseAsync` reads every response into a single fixed **64KiB** buffer (`new byte[65536]`), and both the header loop and `DrainAvailable` are bounded by `totalRead < buffer.Length`. Anything beyond that is silently dropped — no exception, no truncation flag, just a short response that downstream assertions treat as the server's actual reply.

That bound is smaller than the largest request the suite sends.

## What overruns it

Four tests build **100,000-byte** payloads:

| Test | Payload |
|---|---|
| `MAL-LONG-URL` | 100,000-char path |
| `MAL-LONG-HEADER-NAME` | 100,000-char header name |
| `MAL-LONG-HEADER-VALUE` | 100,000-char header value |
| `MAL-LONG-METHOD` | 100,000-char method token |

A server that echoes the offending value back in its error response — a reasonably common thing to do — produces a reply larger than 64KiB. The probe cuts it off and records the fragment. For those cases the result reflects our buffer, not the server's behaviour.

`COOK-OVERSIZED` and `MAL-CHUNK-EXT-64K` send exactly 65,536 bytes, so they sit right on the boundary and overrun as soon as any status line or headers accompany the echo.

## Change

`65536` → `128 * 1024`, extracted to a named `ReadBufferSize` constant with the ceiling documented next to it. 128KiB clears 100,000 bytes with ~30KiB of headroom for the status line and headers.

One buffer is allocated per `ReadResponseAsync` call, so this is +64KiB per read, transient and immediately collectable. No behavioural change for any response that already fit.

## Verification

Builds clean in Release, 0 warnings / 0 errors.

**Not yet run against live servers.** The local hardware this was written on is mid-diagnosis for a suspected memory fault, so the full suite hasn't been executed to confirm the affected tests change verdict. The change is a pure bound increase — it can only make previously-truncated reads complete — but the CI probe run is the real check on whether any `MAL-LONG-*` result shifts.