### PR TITLE
Add uWebSockets.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ __pycache__/
 # Node
 node_modules/
 package-lock.json
+# ...except for servers, where the lock pins the image's dependencies by hash
+!src/Servers/**/package-lock.json
 
 # Probe results (local testing)
 probe-*.json

--- a/docs/content/servers/uwebsockets.md
+++ b/docs/content/servers/uwebsockets.md
@@ -13,15 +13,16 @@ breadcrumbs: false
 # trixie, not the default bookworm: uWS ships prebuilt binaries needing glibc >= 2.38
 FROM node:22-trixie-slim
 WORKDIR /app
-COPY src/Servers/UWebSocketsServer/package.json .
-RUN npm install --omit=dev
+COPY src/Servers/UWebSocketsServer/package.json src/Servers/UWebSocketsServer/package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
 COPY src/Servers/UWebSocketsServer/server.js .
+USER node
 ENTRYPOINT ["node", "server.js", "8080"]
 ```
 
 ## Source — `package.json`
 
-uWebSockets.js is not published to the npm registry, so it is pinned to a release tarball. Release tags carry prebuilt `.node` binaries, so there is no build step.
+uWebSockets.js is not published to the npm registry, so it is pinned to a release tarball. Release tags carry prebuilt `.node` binaries, so there is no build step and no lifecycle scripts to run. A generated `package-lock.json` sits alongside this file, pinning the tarball by sha512 integrity hash so `npm ci` gets identical bytes on every build.
 
 ```json
 {
@@ -38,7 +39,7 @@ uWebSockets.js is not published to the npm registry, so it is pinned to a releas
 ```javascript
 const uWS = require('uWebSockets.js');
 
-const port = parseInt(process.argv[2] || '8080', 10);
+const port = Number.parseInt(process.argv[2] || '8080', 10);
 
 /* uWS invalidates `req` the moment the handler returns, so everything needed
  * later has to be read out synchronously. Only the body echo is async here. */

--- a/docs/content/servers/uwebsockets.md
+++ b/docs/content/servers/uwebsockets.md
@@ -1,0 +1,136 @@
+---
+title: "uWebSockets.js"
+description: "uWebSockets.js (JavaScript) tested against RFC 9110/9112 for HTTP/1.1 compliance, request smuggling resistance, and malformed input handling."
+toc: true
+breadcrumbs: false
+---
+
+**Language:** JavaScript · [View source on GitHub](https://github.com/MDA2AV/Http11Probe/tree/main/src/Servers/UWebSocketsServer)
+
+## Dockerfile
+
+```dockerfile
+# trixie, not the default bookworm: uWS ships prebuilt binaries needing glibc >= 2.38
+FROM node:22-trixie-slim
+WORKDIR /app
+COPY src/Servers/UWebSocketsServer/package.json .
+RUN npm install --omit=dev
+COPY src/Servers/UWebSocketsServer/server.js .
+ENTRYPOINT ["node", "server.js", "8080"]
+```
+
+## Source — `package.json`
+
+uWebSockets.js is not published to the npm registry, so it is pinned to a release tarball. Release tags carry prebuilt `.node` binaries, so there is no build step.
+
+```json
+{
+  "name": "uwebsockets-server",
+  "private": true,
+  "dependencies": {
+    "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.69.0.tar.gz"
+  }
+}
+```
+
+## Source — `server.js`
+
+```javascript
+const uWS = require('uWebSockets.js');
+
+const port = parseInt(process.argv[2] || '8080', 10);
+
+/* uWS invalidates `req` the moment the handler returns, so everything needed
+ * later has to be read out synchronously. Only the body echo is async here. */
+
+function readBody(res, onDone) {
+    const chunks = [];
+    res.onAborted(() => { res.aborted = true; });
+    res.onData((ab, isLast) => {
+        /* The ArrayBuffer is only valid inside this callback — slice(0) copies it. */
+        chunks.push(Buffer.from(ab.slice(0)));
+        if (isLast) onDone(Buffer.concat(chunks));
+    });
+}
+
+const app = uWS.App();
+
+app.any('/cookie', (res, req) => {
+    let body = '';
+    const raw = req.getHeader('cookie');
+    for (const pair of raw.split(';')) {
+        const trimmed = pair.trimStart();
+        const eq = trimmed.indexOf('=');
+        if (eq > 0) body += trimmed.substring(0, eq) + '=' + trimmed.substring(eq + 1) + '\n';
+    }
+    res.writeHeader('Content-Type', 'text/plain');
+    res.end(body);
+});
+
+app.any('/echo', (res, req) => {
+    let body = '';
+    req.forEach((name, value) => { body += name + ': ' + value + '\n'; });
+    res.writeHeader('Content-Type', 'text/plain');
+    res.end(body);
+});
+
+/* Wildcards must be registered last. */
+app.any('/*', (res, req) => {
+    if (req.getMethod() === 'post') {
+        readBody(res, (body) => {
+            if (res.aborted) return;
+            /* Cork when responding from an async callback. */
+            res.cork(() => {
+                res.writeHeader('Content-Type', 'text/plain');
+                res.end(body);
+            });
+        });
+        return;
+    }
+    res.writeHeader('Content-Type', 'text/plain');
+    res.end('OK');
+});
+
+app.listen('0.0.0.0', port, (token) => {
+    if (!token) {
+        console.error('Failed to listen on port ' + port);
+        process.exit(1);
+    }
+});
+```
+
+## Test Results
+
+<div id="server-summary"><p><em>Loading results...</em></p></div>
+
+### Compliance
+
+<div id="results-compliance"></div>
+
+### Smuggling
+
+<div id="results-smuggling"></div>
+
+### Malformed Input
+
+<div id="results-malformedinput"></div>
+
+### Caching
+
+<div id="results-capabilities"></div>
+
+### Cookies
+
+<div id="results-cookies"></div>
+
+<script src="/probe/data.js"></script>
+<script src="/probe/render.js"></script>
+<script>
+(function() {
+  if (!window.PROBE_DATA) {
+    document.getElementById('server-summary').innerHTML = '<p><em>No probe data available yet. Run the Probe workflow on <code>main</code> to generate results.</em></p>';
+    return;
+  }
+  ProbeRender.renderServerPage('uWebSockets.js');
+})();
+</script>

--- a/src/Servers/UWebSocketsServer/Dockerfile
+++ b/src/Servers/UWebSocketsServer/Dockerfile
@@ -1,0 +1,7 @@
+# trixie, not the default bookworm: uWS ships prebuilt binaries needing glibc >= 2.38
+FROM node:22-trixie-slim
+WORKDIR /app
+COPY src/Servers/UWebSocketsServer/package.json .
+RUN npm install --omit=dev
+COPY src/Servers/UWebSocketsServer/server.js .
+ENTRYPOINT ["node", "server.js", "8080"]

--- a/src/Servers/UWebSocketsServer/Dockerfile
+++ b/src/Servers/UWebSocketsServer/Dockerfile
@@ -1,7 +1,8 @@
 # trixie, not the default bookworm: uWS ships prebuilt binaries needing glibc >= 2.38
 FROM node:22-trixie-slim
 WORKDIR /app
-COPY src/Servers/UWebSocketsServer/package.json .
-RUN npm install --omit=dev
+COPY src/Servers/UWebSocketsServer/package.json src/Servers/UWebSocketsServer/package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
 COPY src/Servers/UWebSocketsServer/server.js .
+USER node
 ENTRYPOINT ["node", "server.js", "8080"]

--- a/src/Servers/UWebSocketsServer/package-lock.json
+++ b/src/Servers/UWebSocketsServer/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "uwebsockets-server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "uwebsockets-server",
+      "dependencies": {
+        "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.69.0.tar.gz"
+      }
+    },
+    "node_modules/uWebSockets.js": {
+      "version": "20.69.0",
+      "resolved": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.69.0.tar.gz",
+      "integrity": "sha512-vSARYbg98BfI8G4hB305Oa4iU3Ocon3o+SKzy1iza7hQGECgZSxJJ0/yp7LvPdTdQlY3bVQs+A4Ir7tCGQ2hnA==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/src/Servers/UWebSocketsServer/package.json
+++ b/src/Servers/UWebSocketsServer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "uwebsockets-server",
+  "private": true,
+  "dependencies": {
+    "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.69.0.tar.gz"
+  }
+}

--- a/src/Servers/UWebSocketsServer/probe.json
+++ b/src/Servers/UWebSocketsServer/probe.json
@@ -1,0 +1,1 @@
+{"name": "uWebSockets.js", "language": "JavaScript", "repository": "https://github.com/uNetworking/uWebSockets.js"}

--- a/src/Servers/UWebSocketsServer/server.js
+++ b/src/Servers/UWebSocketsServer/server.js
@@ -1,6 +1,6 @@
 const uWS = require('uWebSockets.js');
 
-const port = parseInt(process.argv[2] || '8080', 10);
+const port = Number.parseInt(process.argv[2] || '8080', 10);
 
 /* uWS invalidates `req` the moment the handler returns, so everything needed
  * later has to be read out synchronously. Only the body echo is async here. */

--- a/src/Servers/UWebSocketsServer/server.js
+++ b/src/Servers/UWebSocketsServer/server.js
@@ -1,0 +1,61 @@
+const uWS = require('uWebSockets.js');
+
+const port = parseInt(process.argv[2] || '8080', 10);
+
+/* uWS invalidates `req` the moment the handler returns, so everything needed
+ * later has to be read out synchronously. Only the body echo is async here. */
+
+function readBody(res, onDone) {
+    const chunks = [];
+    res.onAborted(() => { res.aborted = true; });
+    res.onData((ab, isLast) => {
+        /* The ArrayBuffer is only valid inside this callback — slice(0) copies it. */
+        chunks.push(Buffer.from(ab.slice(0)));
+        if (isLast) onDone(Buffer.concat(chunks));
+    });
+}
+
+const app = uWS.App();
+
+app.any('/cookie', (res, req) => {
+    let body = '';
+    const raw = req.getHeader('cookie');
+    for (const pair of raw.split(';')) {
+        const trimmed = pair.trimStart();
+        const eq = trimmed.indexOf('=');
+        if (eq > 0) body += trimmed.substring(0, eq) + '=' + trimmed.substring(eq + 1) + '\n';
+    }
+    res.writeHeader('Content-Type', 'text/plain');
+    res.end(body);
+});
+
+app.any('/echo', (res, req) => {
+    let body = '';
+    req.forEach((name, value) => { body += name + ': ' + value + '\n'; });
+    res.writeHeader('Content-Type', 'text/plain');
+    res.end(body);
+});
+
+/* Wildcards must be registered last. */
+app.any('/*', (res, req) => {
+    if (req.getMethod() === 'post') {
+        readBody(res, (body) => {
+            if (res.aborted) return;
+            /* Cork when responding from an async callback. */
+            res.cork(() => {
+                res.writeHeader('Content-Type', 'text/plain');
+                res.end(body);
+            });
+        });
+        return;
+    }
+    res.writeHeader('Content-Type', 'text/plain');
+    res.end('OK');
+});
+
+app.listen('0.0.0.0', port, (token) => {
+    if (!token) {
+        console.error('Failed to listen on port ' + port);
+        process.exit(1);
+    }
+});


### PR DESCRIPTION
Two patterns account for most of it:

**1. A generic `505` for anything the parser rejects.** Valid HTTP/1.1 requests come back as `505 HTTP Version Not Supported` with the body `This server does not support HTTP/1.0.` — including `OPTIONS * HTTP/1.1` and a well-formed chunked request with a trailer:

```
POST / HTTP/1.1 · Transfer-Encoding: chunked · 5/hello/0/X-Checksum: abc
→ HTTP/1.1 505 HTTP Version Not Supported
```

This drives most of the Compliance and trailer-related Smuggling failures. The rejection itself is safe; the status code and message are misleading.

**2. Duplicate `Content-Length` is accepted.** `SMUG-DUPLICATE-CL` sends two conflicting lengths and gets a `200` using the first, leaving the remainder in the buffer — a smuggling vector, MUST-level:

```
Content-Length: 5 · Content-Length: 10 · body "helloworld"
→ 200, Content-Length: 5, body "hello"
```

Also worth flagging: `COMP-HEAD-NO-BODY` fails because uWS sends the body on a `HEAD` request (`Content-Length: 2` and `OK` on the wire). Node's `http` suppresses it automatically; uWS does not, so every uWS app has to handle that itself.

These are uWS's own parser behaviours, not artifacts of the harness code in this PR — the `505` bodies are generated by uWS before any handler runs (`<i>uWebSockets/20 Server</i>`).

## Verified locally

Image builds; all six endpoint contracts from the Add a Framework guide check out (`GET /`, `POST /` echo, `HEAD /`, `OPTIONS /`, `POST /echo`, `/cookie`); site build renders `servers/uwebsockets.html` bound to `renderServerPage('uWebSockets.js')`.