### PR TITLE
Add uWebSockets (C++)

### DIFF
--- a/docs/content/servers/uwebsockets-cpp.md
+++ b/docs/content/servers/uwebsockets-cpp.md
@@ -1,0 +1,158 @@
+---
+title: "uWebSockets"
+description: "uWebSockets (C++) tested against RFC 9110/9112 for HTTP/1.1 compliance, request smuggling resistance, and malformed input handling."
+toc: true
+breadcrumbs: false
+---
+
+**Language:** C++ · [View source on GitHub](https://github.com/MDA2AV/Http11Probe/tree/main/src/Servers/UWebSocketsCppServer)
+
+The C++ library, built from `master` rather than a pinned release so upstream fixes show up in these results as they land. `uWebSockets.js` is the Node.js binding over this same core.
+
+## Dockerfile
+
+```dockerfile
+FROM debian:trixie-slim AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates g++ git make zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+# Deliberately unpinned: upstream asked that results track master so their
+# fixes show up here. Rebuilding picks up whatever master is at that moment.
+RUN git clone --depth 1 https://github.com/uNetworking/uWebSockets.git . \
+    && git submodule update --init --depth 1 uSockets
+RUN make -C uSockets
+COPY src/Servers/UWebSocketsCppServer/server.cpp .
+RUN g++ -std=c++2b -O3 -Isrc -IuSockets/src server.cpp uSockets/*.o -lz -o /uws-server
+
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /uws-server /usr/local/bin/uws-server
+USER nobody
+ENTRYPOINT ["uws-server", "8080"]
+```
+
+## Source — `server.cpp`
+
+```cpp
+#include "App.h"
+
+#include <charconv>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+
+/* uWS invalidates req as soon as the handler returns, so everything needed
+ * later is read out synchronously. Only the body echo is async. */
+
+static std::string parseCookies(std::string_view raw) {
+    std::string out;
+    size_t pos = 0;
+    while (pos < raw.size()) {
+        size_t semi = raw.find(';', pos);
+        std::string_view pair = raw.substr(pos, semi == std::string_view::npos ? raw.size() - pos : semi - pos);
+        size_t start = pair.find_first_not_of(" \t");
+        if (start != std::string_view::npos) {
+            pair.remove_prefix(start);
+            size_t eq = pair.find('=');
+            if (eq != std::string_view::npos && eq > 0) {
+                out.append(pair.substr(0, eq));
+                out.push_back('=');
+                out.append(pair.substr(eq + 1));
+                out.push_back('\n');
+            }
+        }
+        if (semi == std::string_view::npos) {
+            break;
+        }
+        pos = semi + 1;
+    }
+    return out;
+}
+
+int main(int argc, char **argv) {
+    int port = 8080;
+    if (argc > 1) {
+        std::string_view arg(argv[1]);
+        std::from_chars(arg.data(), arg.data() + arg.size(), port);
+    }
+
+    uWS::App().any("/cookie", [](auto *res, auto *req) {
+        std::string body = parseCookies(req->getHeader("cookie"));
+        res->writeHeader("Content-Type", "text/plain");
+        res->end(body);
+    }).any("/echo", [](auto *res, auto *req) {
+        std::string body;
+        for (auto [key, value] : *req) {
+            body.append(key);
+            body.append(": ");
+            body.append(value);
+            body.push_back('\n');
+        }
+        res->writeHeader("Content-Type", "text/plain");
+        res->end(body);
+    /* Wildcards must be registered last. */
+    }).any("/*", [](auto *res, auto *req) {
+        if (req->getMethod() != "post") {
+            res->writeHeader("Content-Type", "text/plain");
+            res->end("OK");
+            return;
+        }
+
+        /* Already inside the socket callback, so uWS corks these writes for us. */
+        auto buffer = std::make_shared<std::string>();
+        res->onData([res, buffer](std::string_view chunk, bool isFin) {
+            buffer->append(chunk);
+            if (isFin) {
+                res->writeHeader("Content-Type", "text/plain");
+                res->end(*buffer);
+            }
+        });
+        res->onAborted([]() {});
+    }).listen("0.0.0.0", port, [port](auto *listen_socket) {
+        if (!listen_socket) {
+            std::cerr << "Failed to listen on port " << port << std::endl;
+            std::exit(1);
+        }
+    }).run();
+}
+```
+
+## Test Results
+
+<div id="server-summary"><p><em>Loading results...</em></p></div>
+
+### Compliance
+
+<div id="results-compliance"></div>
+
+### Smuggling
+
+<div id="results-smuggling"></div>
+
+### Malformed Input
+
+<div id="results-malformedinput"></div>
+
+### Caching
+
+<div id="results-capabilities"></div>
+
+### Cookies
+
+<div id="results-cookies"></div>
+
+<script src="/probe/data.js"></script>
+<script src="/probe/render.js"></script>
+<script>
+(function() {
+  if (!window.PROBE_DATA) {
+    document.getElementById('server-summary').innerHTML = '<p><em>No probe data available yet. Run the Probe workflow on <code>main</code> to generate results.</em></p>';
+    return;
+  }
+  ProbeRender.renderServerPage('uWebSockets');
+})();
+</script>

--- a/src/Servers/UWebSocketsCppServer/Dockerfile
+++ b/src/Servers/UWebSocketsCppServer/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:trixie-slim AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates g++ git make zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+# Deliberately unpinned: upstream asked that results track master so their
+# fixes show up here. Rebuilding picks up whatever master is at that moment.
+RUN git clone --depth 1 https://github.com/uNetworking/uWebSockets.git . \
+    && git submodule update --init --depth 1 uSockets
+RUN make -C uSockets
+COPY src/Servers/UWebSocketsCppServer/server.cpp .
+RUN g++ -std=c++2b -O3 -Isrc -IuSockets/src server.cpp uSockets/*.o -lz -o /uws-server
+
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /uws-server /usr/local/bin/uws-server
+USER nobody
+ENTRYPOINT ["uws-server", "8080"]

--- a/src/Servers/UWebSocketsCppServer/probe.json
+++ b/src/Servers/UWebSocketsCppServer/probe.json
@@ -1,0 +1,1 @@
+{"name": "uWebSockets", "language": "C++", "repository": "https://github.com/uNetworking/uWebSockets"}

--- a/src/Servers/UWebSocketsCppServer/server.cpp
+++ b/src/Servers/UWebSocketsCppServer/server.cpp
@@ -1,0 +1,83 @@
+#include "App.h"
+
+#include <charconv>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+
+/* uWS invalidates req as soon as the handler returns, so everything needed
+ * later is read out synchronously. Only the body echo is async. */
+
+static std::string parseCookies(std::string_view raw) {
+    std::string out;
+    size_t pos = 0;
+    while (pos < raw.size()) {
+        size_t semi = raw.find(';', pos);
+        std::string_view pair = raw.substr(pos, semi == std::string_view::npos ? raw.size() - pos : semi - pos);
+        size_t start = pair.find_first_not_of(" \t");
+        if (start != std::string_view::npos) {
+            pair.remove_prefix(start);
+            size_t eq = pair.find('=');
+            if (eq != std::string_view::npos && eq > 0) {
+                out.append(pair.substr(0, eq));
+                out.push_back('=');
+                out.append(pair.substr(eq + 1));
+                out.push_back('\n');
+            }
+        }
+        if (semi == std::string_view::npos) {
+            break;
+        }
+        pos = semi + 1;
+    }
+    return out;
+}
+
+int main(int argc, char **argv) {
+    int port = 8080;
+    if (argc > 1) {
+        std::string_view arg(argv[1]);
+        std::from_chars(arg.data(), arg.data() + arg.size(), port);
+    }
+
+    uWS::App().any("/cookie", [](auto *res, auto *req) {
+        std::string body = parseCookies(req->getHeader("cookie"));
+        res->writeHeader("Content-Type", "text/plain");
+        res->end(body);
+    }).any("/echo", [](auto *res, auto *req) {
+        std::string body;
+        for (auto [key, value] : *req) {
+            body.append(key);
+            body.append(": ");
+            body.append(value);
+            body.push_back('\n');
+        }
+        res->writeHeader("Content-Type", "text/plain");
+        res->end(body);
+    /* Wildcards must be registered last. */
+    }).any("/*", [](auto *res, auto *req) {
+        if (req->getMethod() != "post") {
+            res->writeHeader("Content-Type", "text/plain");
+            res->end("OK");
+            return;
+        }
+
+        /* Already inside the socket callback, so uWS corks these writes for us. */
+        auto buffer = std::make_shared<std::string>();
+        res->onData([res, buffer](std::string_view chunk, bool isFin) {
+            buffer->append(chunk);
+            if (isFin) {
+                res->writeHeader("Content-Type", "text/plain");
+                res->end(*buffer);
+            }
+        });
+        res->onAborted([]() {});
+    }).listen("0.0.0.0", port, [port](auto *listen_socket) {
+        if (!listen_socket) {
+            std::cerr << "Failed to listen on port " << port << std::endl;
+            std::exit(1);
+        }
+    }).run();
+}


### PR DESCRIPTION
So this adds the C++ library, tracking `master`.

## Tracking master, not a tag

The clone is **deliberately unpinned** — that is the whole point of the request. Each rebuild picks up whatever `master` is at that moment, so upstream fixes surface here without a PR.

Worth stating the tradeoff plainly: builds are no longer reproducible, and a broken upstream commit will show up as this server regressing rather than as a build failure. That is the behaviour asked for, but it is the opposite of the lock-file pinning #151 just added, so it should be a conscious choice rather than an inconsistency someone later "fixes".

Only the `uSockets` submodule is initialised; the others are fuzzing corpora and test suites.

## Build

Two stages. `make -C uSockets`, then `g++` with the flags upstream's `build.c` uses — **minus `-march=native`**, which would otherwise bake the builder's CPU into the binary. Runtime stage is `debian:trixie-slim` + `zlib1g`, running as `nobody`.

Endpoints follow upstream's own `EchoBody.cpp` (described there as *"Can be used to test compliance of HTTP spec"*): `any()` routes with the wildcard last, range-for over the request for `/echo`, `onData`/`onAborted` for the body echo. Responses inside `onData` are already corked by uWS, so there is no explicit `cork()`.

## The Node.js remark does not hold for compliance

Built from `fe7da4cb0562`, run against the same suite as #151:

```
Score: 119/159 (40 failed, 22 warnings)  54 unscored  (213 tests)
```

That is **identical to uWebSockets.js — not similar, identical**. Across all 213 tests there are **zero verdict differences**, and exactly one status-code difference:

| Test | uWebSockets.js | uWebSockets (C++) | Verdict |
|---|---|---|---|
| `SMUG-CHUNK-SPILL` | `200` | `505` | Fail in both |

Which makes sense — the Node addon embeds this same C++ parser. Node.js may well constrain throughput, but it is not what is constraining standards behaviour: every finding reported on #151 reproduces here, including the generic `505 "This server does not support HTTP/1.0."` for valid HTTP/1.1 requests and the accepted duplicate `Content-Length`.

That is arguably the more useful result for upstream. Fixes belong in the C++ parser, and both entries will move together when they land.

## Relationship to #151

Independently mergeable — separate directory (`UWebSocketsCppServer`) and separate page slug, no conflicts. Whether to keep both or close #151 is a judgement call: the maintainer said "not JS", but having both is what demonstrates the bindings do not diverge, and it keeps that claim measured rather than assumed. Happy to fold this into a single entry instead.

## Verified locally

Image builds from a clean context; all six endpoint contracts from the Add a Framework guide pass; container runs as `nobody`; site build renders `servers/uwebsockets-cpp.html` bound to `renderServerPage('uWebSockets')`.