### PR TITLE
Refactor response handling for non-POST requests

### DIFF
--- a/src/Servers/UWebSocketsCppServer/server.cpp
+++ b/src/Servers/UWebSocketsCppServer/server.cpp
@@ -60,7 +60,11 @@ int main(int argc, char **argv) {
     }).any("/*", [](auto *res, auto *req) {
         if (req->getMethod() != "post") {
             res->writeHeader("Content-Type", "text/plain");
-            res->end("OK");
+            if (req->getMethod() != "head") {
+                res->end("OK");
+            } else {
+                res->endWithoutBody();
+            }
             return;
         }
 


### PR DESCRIPTION
Change response handling for non-POST requests to differentiate between HEAD and other methods.

[mention](https://github.com/uNetworking/uWebSockets.js/issues/1298#issuecomment-5305051119)
