### PR TITLE
Add Fulmine.js server

### DIFF
--- a/src/Servers/FulmineServer/Dockerfile
+++ b/src/Servers/FulmineServer/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:22-trixie-slim
+# fulmine.js depends on uWebSockets.js, which npm installs from its git tag rather than from the
+# registry, and whose prebuilt binary needs glibc 2.38, which is why this is trixie and not the
+# bookworm -slim every other server here uses. git fetches it over https because npm asks for the
+# repository over ssh by default and this image carries no key.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+WORKDIR /app
+COPY src/Servers/FulmineServer/package.json .
+# the version is pinned rather than ranged, since this repo does not keep lock files, and nothing
+# here needs an install script to run
+RUN npm install --omit=dev --ignore-scripts
+# ExpressServer's application, not a copy of it. Fulmine.js is a drop-in replacement for Express 5,
+# so the package is installed under the name "express" and the same file runs unchanged: what is
+# probed here is the same application as the Express row, with only the framework behind it swapped.
+COPY src/Servers/ExpressServer/server.js .
+USER node
+ENTRYPOINT ["node", "server.js", "8080"]

--- a/src/Servers/FulmineServer/package.json
+++ b/src/Servers/FulmineServer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fulmine-server",
+  "private": true,
+  "dependencies": {
+    "express": "npm:fulmine.js@5.13.3"
+  }
+}

--- a/src/Servers/FulmineServer/probe.json
+++ b/src/Servers/FulmineServer/probe.json
@@ -1,0 +1,1 @@
+{"name": "Fulmine.js", "language": "JavaScript"}


### PR DESCRIPTION
Adds [Fulmine.js](https://github.com/nigrosimone/fulmine.js) as a server under test. It is a
drop-in Express 5 replacement that runs on uWebSockets.js, so its HTTP parsing is µWS's rather than
node's, and the probe says something quite different about it than about Express: 128/159 here
against Express's 147/157 on the same machine, and almost every difference is in the request line
and the chunked framing.

There is no `server.js` in this directory on purpose. The package is installed under the name
`express`, so the Dockerfile copies `ExpressServer/server.js` and runs it unchanged: what is probed
is the same application as the Express row with only the framework behind it swapped, which is the
claim this project exists to make. It also means the two rows cannot drift apart when that file
changes.

Two things about the Dockerfile are forced by uWebSockets.js: it is installed from a git tag rather
than from the registry, so the image needs `git` and an https rewrite, and its prebuilt binary needs
glibc 2.38, so the base image is `node:22-trixie-slim` and not `-slim`.

Ran locally the way the workflow does, with the container on `--network host`: 128/159, 213 tests,
no errors.

One note on the Sonar gate: it fails on the security rating, and what is left is the missing lock
file. `.gitignore` excludes lock files repo-wide, so this uses `npm install` with the version pinned
exactly rather than `npm ci`. Say the word and I will commit a `package-lock.json` for this
directory with an exception in `.gitignore`.
